### PR TITLE
feat(values-schema):values.schema.json修正によるvalues確認強化

### DIFF
--- a/charts/finpay-otelcol/values.schema.json
+++ b/charts/finpay-otelcol/values.schema.json
@@ -1,19 +1,51 @@
 {
-  "$schema": "https://json-schema.org/draft-07/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "finpay-otelcol values schema",
   "type": "object",
+  "additionalProperties": true,
+
+  "definitions": {
+    "image": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "repository": { "type": "string" },
+        "tag": { "type": "string", "minLength": 1 },
+        "pullPolicy": { "type": "string" }
+      },
+      "required": ["tag"]
+    },
+    "componentBase": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "image": { "$ref": "#/definitions/image" }
+      },
+      "required": ["enabled", "image"]
+    }
+  },
+
   "properties": {
     "otelcol": {
-      "type": "object",
-      "properties": {
-        "mode": { "type": "string", "enum": ["normal", "break"] },
-        "break": {
+      "allOf": [
+        { "$ref": "#/definitions/componentBase" },
+        {
           "type": "object",
+          "additionalProperties": true,
           "properties": {
-            "tailSamplingPercentage": { "type": "number" }
-          }
+            "mode": {
+              "type": "string",
+              "enum": ["normal", "break"]
+            }
+          },
+          "required": ["mode"]
         }
-      },
-      "required": ["mode"]
-    }
+      ]
+    },
+
+    "prometheus": { "$ref": "#/definitions/componentBase" },
+    "tempo": { "$ref": "#/definitions/componentBase" },
+    "grafana": { "$ref": "#/definitions/componentBase" }
   }
 }


### PR DESCRIPTION
## 概要

- 必要最低限の内容であったvalus.schema.jsonを修正し、valuesの型ミスやenum逸脱をhelm lint時点で検出してPRで落とすようにしました。

## 変更点

- otelcol/prometheus/tempo/grafana.enable -> boolean
- otelcol/prometheus/tempo/grafana.enable -> 必須かつ、non-empty string
- otelcol.mode -> normal / break の enum

## 動作確認

```bash
# 1) tag を数値にして落ちること

$ cat > /tmp/bad-tag.yaml <<'YAML'
grafana:
  enabled: true
  image:
    tag: 123
YAML

$ helm lint charts/finpay-otelcol -f /tmp/bad-tag.yaml
==> Linting charts/finpay-otelcol
[INFO] Chart.yaml: icon is recommended
[ERROR] values.yaml: - grafana.image.tag: Invalid type. Expected: string, given: integer

[ERROR] templates/: values don't meet the specifications of the schema(s) in the following chart(s):
finpay-otelcol:
- grafana.image.tag: Invalid type. Expected: string, given: integer

Error: 1 chart(s) linted, 1 chart(s) failed
```
```bash
# 2) enabled を文字列にして落ちること

$ cat > /tmp/bad-enabled.yaml <<'YAML'
prometheus:
  enabled: "true"
  image:
    tag: "v2.55.1"
YAML


$ helm lint charts/finpay-otelcol -f /tmp/bad-enabled.yaml
==> Linting charts/finpay-otelcol
[INFO] Chart.yaml: icon is recommended
[ERROR] values.yaml: - prometheus.enabled: Invalid type. Expected: boolean, given: string

[ERROR] templates/: values don't meet the specifications of the schema(s) in the following chart(s):
finpay-otelcol:
- prometheus.enabled: Invalid type. Expected: boolean, given: string


Error: 1 chart(s) linted, 1 chart(s) failed
```

```bash
# 3) mode を enum 外にして落ちること

$ cat > /tmp/bad-mode.yaml <<'YAML'
otelcol:
  enabled: true
  image:
    tag: "0.122.0"
  mode: oops
YAML

$ helm lint charts/finpay-otelcol -f /tmp/bad-mode.yaml
==> Linting charts/finpay-otelcol
[INFO] Chart.yaml: icon is recommended
[ERROR] values.yaml: - otelcol.mode: otelcol.mode must be one of the following: "normal", "break"
- otelcol: Must validate all the schemas (allOf)

[ERROR] templates/: values don't meet the specifications of the schema(s) in the following chart(s):
finpay-otelcol:
- otelcol.mode: otelcol.mode must be one of the following: "normal", "break"
- otelcol: Must validate all the schemas (allOf)


Error: 1 chart(s) linted, 1 chart(s) failed

```