### PR TITLE
feat(security-minimal):egress NetworkPolicy追加

### DIFF
--- a/charts/finpay-otelcol/templates/grafana.deploy.yaml
+++ b/charts/finpay-otelcol/templates/grafana.deploy.yaml
@@ -22,6 +22,9 @@ spec:
         checksum/grafana-dashboards: {{ include (print $.Template.BasePath "/grafana.dashboards.configmap.yaml") . | sha256sum }}
         {{- end }}
     spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: grafana
           image: "{{ .Values.grafana.image.repository }}:{{ .Values.grafana.image.tag }}"
@@ -29,6 +32,12 @@ spec:
           ports:
             - name: http
               containerPort: 3000
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            runAsNonRoot: true
           env:
             - name: GF_SECURITY_ADMIN_USER
               value: {{ .Values.grafana.adminUser | quote }}

--- a/charts/finpay-otelcol/templates/loki.deploy.yaml
+++ b/charts/finpay-otelcol/templates/loki.deploy.yaml
@@ -19,6 +19,9 @@ spec:
         app: loki
         {{- include "finpay.labels" . | nindent 8 }}
     spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: loki
           image: "{{ .Values.loki.image.repository }}:{{ .Values.loki.image.tag }}"
@@ -26,6 +29,12 @@ spec:
           args: ["-config.file=/etc/loki/config.yaml"]
           ports:
             - { name: http, containerPort: 3100 }
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - All
+            runAsNonRoot: true
           readinessProbe:
             httpGet:
               path: /ready

--- a/charts/finpay-otelcol/templates/networkpolicy.yaml
+++ b/charts/finpay-otelcol/templates/networkpolicy.yaml
@@ -1,0 +1,213 @@
+{{- /*
+Egress 最小 NetworkPolicy(port-forward を壊しにくい方針)
+- Ingress は触らない
+- Egress を deny-by-default にして必要分だけ許可
+  - DNS (kube-system/coredns)
+  - grafana -> prometheus/tempo/loki
+  - prometheus -> otelcol-gateway (scrape)
+  - otelcol-gateway -> tempo (otlp grpc)
+*/ -}}
+
+{{- $name := include "finpay.name" . -}}
+
+{{- if .Values.grafana.enabled }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "finpay.fullname" . }}-grafana-egress
+  labels:
+    {{- include "finpay.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app: grafana
+  policyTypes:
+    - Egress
+  egress:
+    # DNS
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchExpressions:
+              - key: k8s-app
+                operator: In
+                values: ["kube-dns", "coredns"]
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    # grafana -> prometheus
+    - to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: {{ $name }}
+              app.kubernetes.io/instance: {{ .Release.Name }}
+              app.kubernetes.io/component: prometheus
+      ports:
+        - protocol: TCP
+          port: 9090
+    # grafana -> tempo (datasource: http)
+    - to:
+        - podSelector:
+            matchLabels:
+              app: tempo
+      ports:
+        - protocol: TCP
+          port: 3200
+    # grafana -> loki (datasource: http)
+    - to:
+        - podSelector:
+            matchLabels:
+              app: loki
+      ports:
+        - protocol: TCP
+          port: 3100
+{{- end }}
+
+{{- if .Values.prometheus.enabled }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "finpay.fullname" . }}-prometheus-egress
+  labels:
+    {{- include "finpay.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: {{ $name }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+      app.kubernetes.io/component: prometheus
+  policyTypes:
+    - Egress
+  egress:
+    # DNS
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchExpressions:
+              - key: k8s-app
+                operator: In
+                values: ["kube-dns", "coredns"]
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    # prometheus -> otelcol-gateway (scrape metrics)
+    - to:
+        - podSelector:
+            matchLabels:
+              app: otelcol-gateway
+      ports:
+        - protocol: TCP
+          port: 8888
+{{- end }}
+
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "finpay.fullname" . }}-otelcol-gateway-egress
+  labels:
+    {{- include "finpay.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app: otelcol-gateway
+  policyTypes:
+    - Egress
+  egress:
+    # DNS
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchExpressions:
+              - key: k8s-app
+                operator: In
+                values: ["kube-dns", "coredns"]
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    # otelcol-gateway -> tempo(OTLP gRPC)
+    - to:
+        - podSelector:
+            matchLabels:
+              app: tempo
+      ports:
+        - protocol: TCP
+          port: 4317
+
+{{- if .Values.loki.enabled }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "finpay.fullname" . }}-loki-egress
+  labels:
+    {{- include "finpay.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app: loki
+  policyTypes:
+    - Egress
+  egress:
+    # DNS only (lokiは基本outbound不要)
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchExpressions:
+              - key: k8s-app
+                operator: In
+                values: ["kube-dns", "coredns"]
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+{{- end }}
+
+{{- if .Values.tempo.enabled}}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "finpay.fullname" . }}-tempo-egress
+  labels:
+    {{- include "finpay.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app: tempo
+  policyTypes:
+    - Egress
+  egress:
+    # DNS only (tempoも基本outbound不要)
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchExpressions:
+              - key: k8s-app
+                operator: In
+                values: ["kube-dns", "coredns"]
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+{{- end }}

--- a/charts/finpay-otelcol/templates/otelcol.deploy.yaml
+++ b/charts/finpay-otelcol/templates/otelcol.deploy.yaml
@@ -17,6 +17,9 @@ spec:
         app: otelcol-gateway
         {{- include "finpay.labels" . | nindent 8 }}
     spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: otelcol
           image: "{{ .Values.otelcol.image.repository }}:{{ .Values.otelcol.image.tag }}"
@@ -27,6 +30,12 @@ spec:
             - { name: otlp-http, containerPort: 4318 }
             - { name: metrics, containerPort: 8888 }
             - { name: health, containerPort: 13133 }
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - All
+            runAsNonRoot: true
           env:
             - name: TEMPO_ENDPOINT
               value: {{ .Values.otelcol.exporters.tempo.endpoint }}

--- a/charts/finpay-otelcol/templates/prometheus.deploy.yaml
+++ b/charts/finpay-otelcol/templates/prometheus.deploy.yaml
@@ -20,6 +20,9 @@ spec:
         app.kubernetes.io/component: prometheus
         {{- include "finpay.labels" . | nindent 8 }}
     spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: prometheus
           image: "{{ .Values.prometheus.image.repository }}:{{ .Values.prometheus.image.tag }}"
@@ -32,6 +35,12 @@ spec:
           ports:
             - name: http
               containerPort: {{ .Values.prometheus.service.port | default 9090 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - All
+            runAsNonRoot: true
           volumeMounts:
             - name: config
               mountPath: /etc/prometheus

--- a/charts/finpay-otelcol/templates/tempo.deploy.yaml
+++ b/charts/finpay-otelcol/templates/tempo.deploy.yaml
@@ -28,6 +28,8 @@ spec:
         runAsUser: 10001
         runAsGroup: 10001
         fsGroup: 10001
+        seccompProfile:
+          type: RuntimeDefault
 
       containers:
         - name: tempo
@@ -35,6 +37,12 @@ spec:
           imagePullPolicy: {{ .Values.tempo.image.pullPolicy }}
           args:
             - "-config.file=/conf/tempo.yaml"
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - All
+            runAsNonRoot: true
           ports:
             - name: http
               containerPort: {{ .Values.tempo.service.port }}


### PR DESCRIPTION
## 概要

finpay-otelcol chartに最小限のセキュリティ設定を追加しました。今回の目的はport-forwardや既存導線を壊さずにrestricted寄りの運用品質を最小差分で適用することです。

## 変更点

- 各deploymentにsecurityContextを追加
  - runAsNonRoot: true
  - allowPrivilegeEscalation: false
  - capabilities.drop: ["ALL"]
  - seccompProfile.type: RuntimeDefault
- templates/networkpolicy.yamlを追加
  - Ingressは制限せず、Egressを最小許可
  - DNSを許可
  - Grafana→Prometheus / Tempo / Lokiを許可
  - Prometheus→otelcol-gatewayを許可
  - otelcol-gateway→Tempoを許可
  - Loki / TempoはDNSのみ許可

```bash
$ kubectl -n monitoring get networkpolicies.networking.k8s.io
NAME                                                      POD-SELECTOR                                                                                                                AGE
finpay-monitoring-finpay-otelcol-grafana-egress           app=grafana                                                                                                                 11h
finpay-monitoring-finpay-otelcol-loki-egress              app=loki                                                                                                                    11h
finpay-monitoring-finpay-otelcol-otelcol-gateway-egress   app=otelcol-gateway                                                                                                         11h
finpay-monitoring-finpay-otelcol-prometheus-egress        app.kubernetes.io/component=prometheus,app.kubernetes.io/instance=finpay-monitoring,app.kubernetes.io/name=finpay-otelcol   11h
finpay-monitoring-finpay-otelcol-tempo-egress             app=tempo                                                                                                                   11h
```

```bash
$ kubectl -n monitoring describe networkpolicies.networking.k8s.io
Name:         finpay-monitoring-finpay-otelcol-grafana-egress
Namespace:    monitoring
Created on:   2026-03-07 21:54:53 +0900 JST
Labels:       app.kubernetes.io/managed-by=Helm
              app.kubernetes.io/part-of=finpay
Annotations:  argocd.argoproj.io/tracking-id: finpay-monitoring:networking.k8s.io/NetworkPolicy:monitoring/finpay-monitoring-finpay-otelcol-grafana-egress
Spec:
  PodSelector:     app=grafana
  Not affecting ingress traffic
  Allowing egress traffic:
    To Port: 53/UDP
    To Port: 53/TCP
    To:
      NamespaceSelector: kubernetes.io/metadata.name=kube-system
      PodSelector: k8s-app in (coredns,kube-dns)
    ----------
    To Port: 9090/TCP
    To:
      PodSelector: app.kubernetes.io/component=prometheus,app.kubernetes.io/instance=finpay-monitoring,app.kubernetes.io/name=finpay-otelcol
    ----------
    To Port: 3200/TCP
    To:
      PodSelector: app=tempo
    ----------
    To Port: 3100/TCP
    To:
      PodSelector: app=loki
  Policy Types: Egress


Name:         finpay-monitoring-finpay-otelcol-loki-egress
Namespace:    monitoring
Created on:   2026-03-07 21:54:53 +0900 JST
Labels:       app.kubernetes.io/managed-by=Helm
              app.kubernetes.io/part-of=finpay
Annotations:  argocd.argoproj.io/tracking-id: finpay-monitoring:networking.k8s.io/NetworkPolicy:monitoring/finpay-monitoring-finpay-otelcol-loki-egress
Spec:
  PodSelector:     app=loki
  Not affecting ingress traffic
  Allowing egress traffic:
    To Port: 53/UDP
    To Port: 53/TCP
    To:
      NamespaceSelector: kubernetes.io/metadata.name=kube-system
      PodSelector: k8s-app in (coredns,kube-dns)
  Policy Types: Egress


Name:         finpay-monitoring-finpay-otelcol-otelcol-gateway-egress
Namespace:    monitoring
Created on:   2026-03-07 21:54:53 +0900 JST
Labels:       app.kubernetes.io/managed-by=Helm
              app.kubernetes.io/part-of=finpay
Annotations:  argocd.argoproj.io/tracking-id:
                finpay-monitoring:networking.k8s.io/NetworkPolicy:monitoring/finpay-monitoring-finpay-otelcol-otelcol-gateway-egress
Spec:
  PodSelector:     app=otelcol-gateway
  Not affecting ingress traffic
  Allowing egress traffic:
    To Port: 53/UDP
    To Port: 53/TCP
    To:
      NamespaceSelector: kubernetes.io/metadata.name=kube-system
      PodSelector: k8s-app in (coredns,kube-dns)
    ----------
    To Port: 4317/TCP
    To:
      PodSelector: app=tempo
  Policy Types: Egress


Name:         finpay-monitoring-finpay-otelcol-prometheus-egress
Namespace:    monitoring
Created on:   2026-03-07 21:54:53 +0900 JST
Labels:       app.kubernetes.io/managed-by=Helm
              app.kubernetes.io/part-of=finpay
Annotations:  argocd.argoproj.io/tracking-id:
                finpay-monitoring:networking.k8s.io/NetworkPolicy:monitoring/finpay-monitoring-finpay-otelcol-prometheus-egress
Spec:
  PodSelector:     app.kubernetes.io/component=prometheus,app.kubernetes.io/instance=finpay-monitoring,app.kubernetes.io/name=finpay-otelcol
  Not affecting ingress traffic
  Allowing egress traffic:
    To Port: 53/UDP
    To Port: 53/TCP
    To:
      NamespaceSelector: kubernetes.io/metadata.name=kube-system
      PodSelector: k8s-app in (coredns,kube-dns)
    ----------
    To Port: 8888/TCP
    To:
      PodSelector: app=otelcol-gateway
  Policy Types: Egress


Name:         finpay-monitoring-finpay-otelcol-tempo-egress
Namespace:    monitoring
Created on:   2026-03-07 21:54:53 +0900 JST
Labels:       app.kubernetes.io/managed-by=Helm
              app.kubernetes.io/part-of=finpay
Annotations:  argocd.argoproj.io/tracking-id: finpay-monitoring:networking.k8s.io/NetworkPolicy:monitoring/finpay-monitoring-finpay-otelcol-tempo-egress
Spec:
  PodSelector:     app=tempo
  Not affecting ingress traffic
  Allowing egress traffic:
    To Port: 53/UDP
    To Port: 53/TCP
    To:
      NamespaceSelector: kubernetes.io/metadata.name=kube-system
      PodSelector: k8s-app in (coredns,kube-dns)
  Policy Types: Egress
```